### PR TITLE
Fix frontend container missing Vite dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./frontend:/app
-    command: ["npm", "run", "dev"]
+      - /app/node_modules
+    command: ["sh", "-c", "npm install && npm run dev"]
     ports:
       - "5173:5173"
     environment:


### PR DESCRIPTION
## Summary
- ensure the frontend container retains its node_modules directory instead of overlaying it with the host bind mount
- run npm install before starting the dev server so the Vite binary is available inside the container

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ee3f6bd198832f8d3ed82bef10c76a